### PR TITLE
Start location fix & findings on OutOfIndex error

### DIFF
--- a/mods/ts/maps/blank-conquest/map.yaml
+++ b/mods/ts/maps/blank-conquest/map.yaml
@@ -41,7 +41,7 @@ Players:
 
 Actors:
 	Actor0: mpspawn
-		Location: 5,0
+		Location: 5,20
 		Owner: Neutral
 
 Smudges:


### PR DESCRIPTION
@Mailaender mentioned on PPM that this is currently on hold due to 'segfaulting' (I don't even know what that means, to be honest), so I thought 'you never know until you try' and took a look.

Not sure whether this is what he was referring to, but this at least fixes the out of index error on the test map, should make debugging easier.

From what I could gather, it seems the Actor Location calculation is the culprit. It tries to position actors along X,Y but uses the U/V values for non-rectangle maps in Maps.cs. The result is that if c.X is higher than c.Y, the actor location for V will actually be negative and result in an out of index error.

In other words, a "Location: 5,20" like in the fixed map results in an actual position of "12.5,15", while "5,0" resulted in 2.5,-5", leaving the actor outside the top border of the map.

I hope this helps...
