### PR TITLE
Fix a floating point comparison in combined.frag

### DIFF
--- a/glsl/combined.frag
+++ b/glsl/combined.frag
@@ -261,7 +261,7 @@ void main()
 
 	{
 		// A negative tint alpha indicates that the tint should replace the colour instead of multiplying it
-		if (vTint.a < 0.0 && c.a > 0)
+		if (vTint.a < 0.0 && c.a > 0.0)
 			c = vec4(vTint.rgb, -vTint.a);
 		else
 			c *= vTint;


### PR DESCRIPTION
Otherwise this crashes for me:
```
GL Info Log:
ERROR: 0:264: '>' : wrong operand types - no operation '>' exists that takes a left-hand operand of type 'mediump float' and a right operand of type 'const int' (or there is no acceptable conversion)

System.InvalidProgramException: Compile error in shader object '\Mobius\engine\bin\..\glsl\combined.frag'
   at OpenRA.Platforms.Default.Shader.CompileShaderObject(Int32 type, String name) in \Mobius\engine\OpenRA.Platforms.Default\Shader.cs:line 63
   at OpenRA.Platforms.Default.Shader..ctor(String name) in \Mobius\engine\OpenRA.Platforms.Default\Shader.cs:line 72
   at OpenRA.Platforms.Default.Sdl2GraphicsContext.CreateShader(String name) in \Mobius\engine\OpenRA.Platforms.Default\Sdl2GraphicsContext.cs:line 97
   at OpenRA.Renderer..ctor(IPlatform platform, GraphicSettings graphicSettings) in \Mobius\engine\OpenRA.Game\Renderer.cs:line 88
   at OpenRA.Game.Initialize(Arguments args) in \Mobius\engine\OpenRA.Game\Game.cs:line 368
GL Info Log:
ERROR: 0:264: '>' : wrong operand types - no operation '>' exists that takes a left-hand operand of type 'mediump float' and a right operand of type 'const int' (or there is no acceptable conversion)

System.InvalidProgramException: Compile error in shader object '\Mobius\engine\bin\..\glsl\combined.frag'
   at OpenRA.Platforms.Default.Shader.CompileShaderObject(Int32 type, String name) in \Mobius\engine\OpenRA.Platforms.Default\Shader.cs:line 63
   at OpenRA.Platforms.Default.Shader..ctor(String name) in \Mobius\engine\OpenRA.Platforms.Default\Shader.cs:line 72
   at OpenRA.Platforms.Default.Sdl2GraphicsContext.CreateShader(String name) in \Mobius\engine\OpenRA.Platforms.Default\Sdl2GraphicsContext.cs:line 97
   at OpenRA.Renderer..ctor(IPlatform platform, GraphicSettings graphicSettings) in \Mobius\engine\OpenRA.Game\Renderer.cs:line 88
   at OpenRA.Game.Initialize(Arguments args) in \Mobius\engine\OpenRA.Game\Game.cs:line 368

```